### PR TITLE
copy.sh: Fix script for Gentoo

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -26,7 +26,7 @@ function create {
 	cp $PWD/LICENSE $DIR
 	cd $DIR
 	set -x
-	pip install -e .
+	pip install --user -e .
 }
 
 if [ -d "$DIR" ]; then


### PR DESCRIPTION
Gentoo requires the use of `--user` for pip installations to avoid breaking `python-exec`:

ERROR: (Gentoo) Please run pip with the --user option to avoid breaking python-exec